### PR TITLE
Remove imu/rpy secondary Topic

### DIFF
--- a/imu_rep_draft.rst
+++ b/imu_rep_draft.rst
@@ -84,9 +84,6 @@ Topics
 
 The following topics are expected to be common to many devices. An IMU device driver is expected to publish at least one primary topic. Note that some of these topics may be published by support libraries, rather than the driver implementation. All below message types are supplemented with a std_msgs/Header, containing time and coordinate frame information.
 
-Primary
-'''''''
-
 All primary message types provide a covariance matrix (see REP 103 [1]_) alongside the data field (`*_covariance`). Unreported data dimensions should specify a diagonal covariance of `-1`.
 
 * `imu/data_raw` (sensor_msgs/Imu)
@@ -100,13 +97,6 @@ All primary message types provide a covariance matrix (see REP 103 [1]_) alongsi
 * `imu/mag` (sensor_msgs/MagneticField)
 
   - Sensor output containing magnetometer data.
-
-Secondary
-'''''''''
-
-* `imu/rpy` (geometry_msgs/Vector3Stamped)
-
-  - Supplementary orientation estimate converted to fixed-axis RPY form.
 
 Frame Id
 ''''''''


### PR DESCRIPTION
The imu/rpy secondary topic should be removed. A [Vector3](https://github.com/ros/common_msgs/blob/d4b7d2bdc65c06d11d9e6a020d719874b5ce371a/geometry_msgs/msg/Vector3.msg) represents a vector in free space, not an orientation. All orientations in ROS should be published as quaternions; if the subscriber needs Euler angles, they have to convert the quaternion to Euler themselves.

I know we publish the imu/rpy topic in imu_filter_madgwick, but that's an ugly hack and should not be codified into a REP.